### PR TITLE
Use standard Go gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,30 @@
-.idea/
-*.iml
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# external packages folder
+vendor/


### PR DESCRIPTION
From: https://github.com/github/gitignore/blob/master/Go.gitignore

`.idea`, `.iml` and other IDE-specific files should be gitignored using your machine's global gitignore at `~/.gitignore`. See https://help.github.com/articles/ignoring-files/#create-a-global-gitignore for details